### PR TITLE
fix for the last commit (msm8930) -> rtc and pmic noise gate

### DIFF
--- a/arch/arm/mach-msm/board-8930-pmic.c
+++ b/arch/arm/mach-msm/board-8930-pmic.c
@@ -365,7 +365,7 @@ static struct pm8xxx_mpp_platform_data pm8xxx_mpp_pdata __devinitdata = {
 };
 
 static struct pm8xxx_rtc_platform_data pm8xxx_rtc_pdata __devinitdata = {
-	.rtc_write_enable	= false,
+	.rtc_write_enable	= true,
 	.rtc_alarm_powerup	= false,
 };
 
@@ -705,7 +705,7 @@ static struct pm8xxx_misc_platform_data pm8xxx_misc_pdata = {
 
 static struct pm8xxx_spk_platform_data pm8xxx_spk_pdata = {
 	.spk_add_enable		= false,
-	.cd_ng_threshold	= 0x6,
+	.cd_ng_threshold	= 0x0,
 	.cd_nf_preamp_bias	= 0x1,
 	.cd_ng_hold		= 0x6,
 	.cd_ng_max_atten	= 0x0,


### PR DESCRIPTION
Hi,

it seems that the previous commit reseted important changes for rtc and the noise gate.

Regards Zaolin
