### PR TITLE
block: Set BFQ Slice Idle to 0

### DIFF
--- a/block/bfq-iosched.c
+++ b/block/bfq-iosched.c
@@ -80,7 +80,7 @@ static const int bfq_back_max = 16 * 1024;
 static const int bfq_back_penalty = 2;
 
 /* Idling period duration, in jiffies. */
-static int bfq_slice_idle = HZ / 125;
+static int bfq_slice_idle = 0;
 
 /* Default maximum budget values, in sectors and number of requests. */
 static const int bfq_default_max_budget = 16 * 1024;
@@ -4163,7 +4163,7 @@ static int __init bfq_init(void)
 	 * Can be 0 on HZ < 1000 setups.
 	 */
 	if (bfq_slice_idle == 0)
-		bfq_slice_idle = 1;
+		bfq_slice_idle = 0;
 
 	if (bfq_timeout_async == 0)
 		bfq_timeout_async = 1;


### PR DESCRIPTION
block: Set BFQ Slice Idle to 0
Much like CFQ, BFQ slice idle should be 0 since we do not have a SATA or other spinning disk type storage.

From the documentation "Setting slice_idle to 0 will remove all the idling on queues/service tree level and one should see an overall improved throughput on faster storage devices"

Signed-off-by: Chet Kener Cl3Kener@gmail.com

https://github.com/Cl3Kener/UBER-L/commit/78472fc8263c8faafd3c5d0e49b75ef73a0922cc
