### PR TITLE
block: Set CFQ Slice Idle Default to 0

### DIFF
--- a/block/cfq-iosched.c
+++ b/block/cfq-iosched.c
@@ -30,7 +30,7 @@ static const int cfq_back_penalty = 2;
 static const int cfq_slice_sync = HZ / 10;
 static int cfq_slice_async = HZ / 25;
 static const int cfq_slice_async_rq = 2;
-static int cfq_slice_idle = HZ / 125;
+static int cfq_slice_idle = 0;
 static int cfq_group_idle = HZ / 125;
 static const int cfq_target_latency = HZ * 3/10; /* 300 ms */
 static const int cfq_hist_divisor = 4;
@@ -3902,7 +3902,7 @@ static int __init cfq_init(void)
 	if (!cfq_slice_async)
 		cfq_slice_async = 1;
 	if (!cfq_slice_idle)
-		cfq_slice_idle = 1;
+		cfq_slice_idle = 0;
 
 #ifdef CONFIG_CFQ_GROUP_IOSCHED
 	if (!cfq_group_idle)


### PR DESCRIPTION
From https://www.kernel.org/doc/Documentation/block/cfq-iosched.txt we read "Setting slice_idle to 0 will remove all the idling on queues/service tree level and one should see an overall improved throughput on faster storage devices"

We have a faster storage device so let's make sure we use it properly

(Note: if you read the full descriptor slice idle only seems to benefit spinning type hard drives which we don't have)

Signed-off-by: Chet Kener Cl3Kener@gmail.com

https://github.com/Cl3Kener/UBER-L/commit/45e74f49e4500dd1f312ba7492af5d93dbf3591c
